### PR TITLE
Propagate delay notes in ETA segments

### DIFF
--- a/js/etaCalc.js
+++ b/js/etaCalc.js
@@ -95,7 +95,7 @@ function calculateTrip(params) {
     segmentIndex++;
     const segmentAvail = segmentIndex === 1 ? firstSegmentAvailableTime : defaultAvailableTime;
 
-    const { extraDelay, ferryAsRest, ferryDelay } = getSegmentDelays(segmentIndex, refuelEvents, ferryEvent, mergedSettings);
+    const { extraDelay, delayNotes, ferryAsRest, ferryDelay } = getSegmentDelays(segmentIndex, refuelEvents, ferryEvent, mergedSettings);
 
     let plannedDrive = Math.min(segmentAvail, remainingDrive);
     let inShiftBreak = (state.isSingle && plannedDrive > 4.5) ? 0.75 : 0;
@@ -141,7 +141,8 @@ function calculateTrip(params) {
         driveTime: 0,
         delayOnDuty: countedDelay,
         delayOffDuty: offDutyDelay,
-        inShiftBreak
+        inShiftBreak,
+        delayNotes
       });
 
       if (remainingDrive > 0 && ferryAsRest) {
@@ -170,7 +171,8 @@ function calculateTrip(params) {
       driveTime: plannedDrive,
       delayOnDuty: countedDelay,
       delayOffDuty: offDutyDelay,
-      inShiftBreak
+      inShiftBreak,
+      delayNotes
     });
 
     if (remainingDrive > 0 && ferryAsRest) {

--- a/js/etaCalc.test.js
+++ b/js/etaCalc.test.js
@@ -80,3 +80,22 @@ test('calculateTrip counts qualifying ferry time toward daily rest', () => {
   assert.strictEqual(result.rests[0].end.toISOString(), '2023-01-01T20:45:00.000Z');
 });
 
+test('calculateTrip attaches delay notes to segments', () => {
+  const start = new Date('2023-01-01T00:00:00Z');
+  const result = calculateTrip({
+    baseTime: 5,
+    defaultAvailableTime: 9,
+    firstSegmentAvailableTime: 9,
+    driverType: 'single',
+    speed: 80,
+    startTime: start,
+    refuelEvents: [{ segment: 1, delay: 1 }],
+    ferryEvent: { segment: 1, delay: 7 },
+    settings: { delayMode: 'auto', autoFerryRest: true, autoFerryRestThreshold: 6 }
+  });
+  const notes = result.segments[0].delayNotes;
+  assert.ok(Array.isArray(notes));
+  assert.ok(notes.includes('refuel 1.00h'));
+  assert.ok(notes.includes('ferry 7.00h'));
+});
+


### PR DESCRIPTION
## Summary
- expose delay notes from `getSegmentDelays` through `calculateTrip`
- add coverage verifying segment delay notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7cd4ea38832cbc7f190e0ead0e0e