### PR TITLE
Handle BW tags in week data exporter

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,17 +764,33 @@ function convertCSV() {
 
 <script>
 function parseTruckTrailer(str) {
-  str = str.replace(/\[BW\/[A-Z]\]/gi, "").trim();
+  // Capture a bracketed tag like [BW/P], [BW/PV], [BW/EK], etc.
+  // General format: [PREFIX/CODE] where PREFIX is letters and CODE is 1-3 letters.
+  let bwTag = null;
+  const tagMatch = str.match(/\[([A-Z]+)\/([A-Z]{1,3})\]/i);
+  if (tagMatch) {
+    bwTag = `${tagMatch[1].toUpperCase()}/${tagMatch[2].toUpperCase()}`;
+  }
+
+  // Remove all bracketed [X/YY] tokens before parsing the rest
+  str = str.replace(/\[[A-Z]+\/[A-Z]{1,3}\]/gi, "").trim();
+
+  // Detect driver count (default = 2, but if "1v" is found => 1)
   let drivers = 2;
   if (/1v/i.test(str)) drivers = 1;
+
+  // Split on the first slash to separate truck vs. trailer
   let [left, right = ""] = str.split("/", 2);
   left = left.trim();
   right = right.trim();
+
+  // Extract the first alphanumeric chunk in each side
   const truckMatch = left.match(/[A-Z0-9]+/i);
   const trailerMatch = right.match(/[A-Z0-9]+/i);
   const truck = truckMatch ? truckMatch[0] : left;
   const trailer = trailerMatch ? trailerMatch[0] : right;
-  return { truck, trailer, drivers };
+
+  return { truck, trailer, drivers, bwTag };
 }
 function parseCommaFloat(val) {
   if (!val || val.toString().trim() === "") return null;
@@ -783,35 +799,50 @@ function parseCommaFloat(val) {
 }
 function mergeByTruck(rows) {
   const byTruck = {};
+
   for (let r of rows) {
     const truck = r.Truck;
     if (!byTruck[truck]) {
       byTruck[truck] = r;
     } else {
       const existing = byTruck[truck];
+
       const newHasW7 = r["Week 7"] != null;
       const oldHasW7 = existing["Week 7"] != null;
+
+      // Helper: preserve BW Tag on the main record
+      const ensureBWTag = (keeper, donor) => {
+        if ((keeper["BW Tag"] == null || keeper["BW Tag"] === "") && donor["BW Tag"]) {
+          keeper["BW Tag"] = donor["BW Tag"];
+        }
+      };
+
       if (newHasW7 && !oldHasW7) {
         if (r["Week 6"] == null && existing["Week 6"] != null) {
           r["Week 6"] = existing["Week 6"];
         }
+        ensureBWTag(r, existing);
         byTruck[truck] = r;
       } else if (oldHasW7 && !newHasW7) {
         if (existing["Week 6"] == null && r["Week 6"] != null) {
           existing["Week 6"] = r["Week 6"];
         }
+        ensureBWTag(existing, r);
       } else if (oldHasW7 && newHasW7) {
         if (r["Week 6"] == null && existing["Week 6"] != null) {
           r["Week 6"] = existing["Week 6"];
         }
+        ensureBWTag(r, existing);
         byTruck[truck] = r;
       } else {
         if (existing["Week 6"] == null && r["Week 6"] != null) {
           existing["Week 6"] = r["Week 6"];
         }
+        ensureBWTag(existing, r);
       }
     }
   }
+
   return Object.values(byTruck);
 }
 function transformData(dataAoA) {
@@ -825,10 +856,11 @@ function transformData(dataAoA) {
     const rawTruckTrailer = row[0].toString().trim();
     const week6Val = parseCommaFloat(row[1]);
     const week7Val = parseCommaFloat(row[2]);
-    const { truck, trailer, drivers } = parseTruckTrailer(rawTruckTrailer);
+    const { truck, trailer, drivers, bwTag } = parseTruckTrailer(rawTruckTrailer);
     rows.push({
       Truck: truck,
       Trailer: trailer,
+      "BW Tag": bwTag || "",
       "Week 6": week6Val,
       "Week 7": week7Val,
       Drivers: drivers
@@ -848,6 +880,7 @@ function transformData(dataAoA) {
   merged.push({
     Truck: "",
     Trailer: "Total Average:",
+    "BW Tag": "",
     "Week 6": avg6,
     "Week 7": avg7,
     Drivers: ""
@@ -855,6 +888,7 @@ function transformData(dataAoA) {
   merged.push({
     Truck: "",
     Trailer: "Total Amount:",
+    "BW Tag": "",
     "Week 6": total6,
     "Week 7": total7,
     Drivers: ""
@@ -862,11 +896,12 @@ function transformData(dataAoA) {
   return merged;
 }
 function createStyledSheet(data) {
-  const aoa = [["Truck", "Trailer", "Week 6", "Week 7", "Drivers"]];
+  const aoa = [["Truck", "Trailer", "BW Tag", "Week 6", "Week 7", "Drivers"]];
   data.forEach(row => {
     aoa.push([
       row.Truck,
       row.Trailer,
+      row["BW Tag"] == null ? "" : row["BW Tag"],
       row["Week 6"] == null ? "" : row["Week 6"],
       row["Week 7"] == null ? "" : row["Week 7"],
       row.Drivers == null ? "" : row.Drivers
@@ -874,9 +909,9 @@ function createStyledSheet(data) {
   });
   const ws = XLSX.utils.aoa_to_sheet(aoa);
   ws['!cols'] = [
-    { wch: 10 }, { wch: 12 }, { wch: 10 }, { wch: 10 }, { wch: 8 }
+    { wch: 10 }, { wch: 12 }, { wch: 10 }, { wch: 10 }, { wch: 10 }, { wch: 8 }
   ];
-  const headerCells = ["A1", "B1", "C1", "D1", "E1"];
+  const headerCells = ["A1", "B1", "C1", "D1", "E1", "F1"];
   headerCells.forEach(cellAddr => {
     if (ws[cellAddr]) {
       ws[cellAddr].s = {
@@ -889,7 +924,7 @@ function createStyledSheet(data) {
   const totalAvgRowIndex = aoa.length - 2;
   const totalAmtRowIndex = aoa.length - 1;
   [totalAvgRowIndex, totalAmtRowIndex].forEach(rowIndex => {
-    for (let col = 0; col < 5; col++) {
+    for (let col = 0; col < 6; col++) {
       const addr = XLSX.utils.encode_cell({ r: rowIndex, c: col });
       if (!ws[addr]) continue;
       ws[addr].s = ws[addr].s || {};


### PR DESCRIPTION
## Summary
- capture bracketed BW tags and driver count when parsing truck/trailer strings
- preserve BW tag when merging records and include column in exported sheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad4dffee48832ca35759e6bec4e680